### PR TITLE
[feat] 메인 페이지 기능 추가

### DIFF
--- a/src/main/java/com/bootcamp/savemypodo/controller/PerformanceController.java
+++ b/src/main/java/com/bootcamp/savemypodo/controller/PerformanceController.java
@@ -1,0 +1,49 @@
+package com.bootcamp.savemypodo.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.bootcamp.savemypodo.dto.performance.PerformanceResponseDto;
+import com.bootcamp.savemypodo.entity.PerformanceSortType;
+import com.bootcamp.savemypodo.entity.User;
+import com.bootcamp.savemypodo.service.PerformanceService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/api")
+public class PerformanceController {
+	
+	private final PerformanceService performanceService;
+	
+	@GetMapping("/performances")
+    @ResponseBody
+    public List<PerformanceResponseDto> getPerformances(
+            @RequestParam(defaultValue = "LATEST") PerformanceSortType sort) {
+
+        Long userId = null;
+
+        if (sort == PerformanceSortType.MINE) {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication != null && authentication.isAuthenticated()) {
+                Object principal = authentication.getPrincipal();
+
+                if (principal instanceof User user) {
+                    userId = user.getId();
+                }
+            }
+        }
+
+        return performanceService.getPerformances(sort, userId);
+    }
+
+}

--- a/src/main/java/com/bootcamp/savemypodo/controller/ReservationController.java
+++ b/src/main/java/com/bootcamp/savemypodo/controller/ReservationController.java
@@ -1,0 +1,85 @@
+package com.bootcamp.savemypodo.controller;
+
+import com.bootcamp.savemypodo.entity.User;
+import com.bootcamp.savemypodo.dto.reservation.ReservationResponseDto;
+import com.bootcamp.savemypodo.entity.Performance;
+import com.bootcamp.savemypodo.repository.PerformanceRepository;
+import com.bootcamp.savemypodo.repository.ReservationRepository;
+//import com.bootcamp.savemypodo.security.CustomUserPrincipal;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reservations")
+public class ReservationController {
+
+    private final ReservationRepository reservationRepository;
+    private final PerformanceRepository performanceRepository;
+
+    // 예매 상태 조회
+    @GetMapping("/status")
+    public ResponseEntity<ReservationResponseDto> getReservationStatus(
+            @RequestParam Long pid,
+            Authentication authentication) {
+
+        Long userId = null;
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object principal = authentication.getPrincipal();
+            if (principal instanceof User user) {
+                userId = user.getId();
+            }
+        }
+
+        Performance performance = performanceRepository.findById(pid)
+                .orElseThrow(() -> new RuntimeException("공연을 찾을 수 없습니다."));
+        // 전체 좌석 수
+        int seatNumber = performance.getSeatNumber();
+        
+        // 예매된 좌석 수
+        int currentReserved = reservationRepository.countByPerformance_Pid(pid);
+        boolean soldOut = currentReserved >= performance.getSeatNumber();
+
+        boolean reserved = false;
+        if (userId != null) {
+            reserved = reservationRepository.existsByUser_IdAndPerformance_Pid(userId, pid);
+        }
+
+        return ResponseEntity.ok(new ReservationResponseDto(
+        		reserved,
+        		soldOut,
+        		seatNumber,
+        		currentReserved));
+    }
+
+    // 예매 취소
+    @DeleteMapping("/{pid}")
+    public ResponseEntity<Void> cancelReservation(
+            @PathVariable Long pid,
+            Authentication authentication) {
+
+        Long userId = null;
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object principal = authentication.getPrincipal();
+            if (principal instanceof User user) {
+                userId = user.getId();
+            }
+        }
+
+        if (userId == null) {
+            return ResponseEntity.status(401).build(); // 인증 실패
+        }
+
+        boolean exists = reservationRepository.existsByUser_IdAndPerformance_Pid(userId, pid);
+        if (!exists) {
+            return ResponseEntity.status(404).build(); // 예매 기록 없음
+        }
+
+        reservationRepository.deleteByUser_IdAndPerformance_Pid(userId, pid);
+        return ResponseEntity.noContent().build(); // 성공적으로 삭제됨
+    }
+}
+

--- a/src/main/java/com/bootcamp/savemypodo/dto/performance/PerformanceResponseDto.java
+++ b/src/main/java/com/bootcamp/savemypodo/dto/performance/PerformanceResponseDto.java
@@ -1,0 +1,28 @@
+package com.bootcamp.savemypodo.dto.performance;
+
+import java.time.LocalDateTime;
+import com.bootcamp.savemypodo.entity.Performance;
+
+public record PerformanceResponseDto(
+        Long pid,
+        String title,
+        String summary,
+        LocalDateTime date,
+        int price,
+        int seatNumber,
+        int reservedSeats
+) {
+    public static PerformanceResponseDto from(Performance performance, int reservedSeats) {
+        return new PerformanceResponseDto(
+                performance.getPid(),
+                performance.getTitle(),
+                performance.getSummary(),
+                performance.getDate(),
+                performance.getPrice(),
+                performance.getSeatNumber(),
+                reservedSeats // 여기 주의: reservedSeats는 매개변수에서 받아온 값을 사용해야 합니다.
+        );
+    }
+}
+
+

--- a/src/main/java/com/bootcamp/savemypodo/dto/reservation/ReservationResponseDto.java
+++ b/src/main/java/com/bootcamp/savemypodo/dto/reservation/ReservationResponseDto.java
@@ -1,0 +1,10 @@
+package com.bootcamp.savemypodo.dto.reservation;
+
+public record ReservationResponseDto(
+ boolean reserved,
+ boolean soldOut,
+ int seatNumber,
+ int currentReserved
+) {}
+
+

--- a/src/main/java/com/bootcamp/savemypodo/entity/Performance.java
+++ b/src/main/java/com/bootcamp/savemypodo/entity/Performance.java
@@ -1,0 +1,31 @@
+package com.bootcamp.savemypodo.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "performances")
+public class Performance {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long pid;
+	private String title;
+	private String summary ;
+	private LocalDateTime date;
+	private int price;
+	
+	@Transient
+	private int reservedSeats;
+	
+	@Column(name = "seat_number")
+	private int seatNumber;
+}

--- a/src/main/java/com/bootcamp/savemypodo/entity/PerformanceSortType.java
+++ b/src/main/java/com/bootcamp/savemypodo/entity/PerformanceSortType.java
@@ -1,0 +1,7 @@
+package com.bootcamp.savemypodo.entity;
+
+public enum PerformanceSortType {
+	LATEST,
+	POPULAR,
+	MINE
+}

--- a/src/main/java/com/bootcamp/savemypodo/entity/Reservation.java
+++ b/src/main/java/com/bootcamp/savemypodo/entity/Reservation.java
@@ -1,0 +1,25 @@
+package com.bootcamp.savemypodo.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "reservations")
+public class Reservation {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	@ManyToOne
+	@JoinColumn(name = "uid")
+	private User user;
+	
+	@ManyToOne
+	@JoinColumn(name = "pid")
+	private Performance performance;
+}

--- a/src/main/java/com/bootcamp/savemypodo/repository/PerformanceRepository.java
+++ b/src/main/java/com/bootcamp/savemypodo/repository/PerformanceRepository.java
@@ -1,0 +1,32 @@
+package com.bootcamp.savemypodo.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.bootcamp.savemypodo.entity.Performance;
+
+@Repository
+public interface PerformanceRepository extends JpaRepository<Performance, Long> {
+	// table 이름과 entity에서 정의한 변수 이름 확인 -> 
+	
+	// 공연 테이블에서 공연을 최신순으로 정렬
+	@Query("SELECT p FROM Performance p ORDER BY p.date DESC")
+	List<Performance> findAllByLatest();
+	
+	// 예매 순 정렬
+	@Query("""
+			SELECT p FROM Performance p 
+			LEFT JOIN Reservation r ON r.performance = p
+			GROUP BY p
+			ORDER BY COUNT(r.id) DESC
+			""")
+	List<Performance> findAllByPopular();
+	
+	// 내가 예매한 공연, performance는 reservation entity에 있는 pid 변수 이름
+	@Query("SELECT r.performance FROM Reservation r WHERE r.user.id = :userId")
+	List<Performance> findAllByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/bootcamp/savemypodo/repository/ReservationRepository.java
+++ b/src/main/java/com/bootcamp/savemypodo/repository/ReservationRepository.java
@@ -1,0 +1,18 @@
+package com.bootcamp.savemypodo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+import com.bootcamp.savemypodo.entity.Reservation;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+	// 공연 ID로 예약된 row 개수 반환
+    int countByPerformance_Pid(Long pid);
+    
+    // 해당 유저가 해당 공연을 예매했는지
+    boolean existsByUser_IdAndPerformance_Pid(Long uid, Long pid);  
+    
+    // 예매 취소
+    void deleteByUser_IdAndPerformance_Pid(@Param("uid") Long uid, @Param("pid") Long pid);
+}

--- a/src/main/java/com/bootcamp/savemypodo/service/PerformanceService.java
+++ b/src/main/java/com/bootcamp/savemypodo/service/PerformanceService.java
@@ -1,0 +1,38 @@
+package com.bootcamp.savemypodo.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.bootcamp.savemypodo.dto.performance.PerformanceResponseDto;
+import com.bootcamp.savemypodo.entity.Performance;
+import com.bootcamp.savemypodo.entity.PerformanceSortType;
+import com.bootcamp.savemypodo.repository.PerformanceRepository;
+import com.bootcamp.savemypodo.repository.ReservationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceService {
+	private final PerformanceRepository performanceRepository;
+	private final ReservationRepository reservationRepository;
+	
+	public List<PerformanceResponseDto> getPerformances(PerformanceSortType sortType, Long userId){
+		List<Performance> performances;
+        switch (sortType) {
+            case POPULAR -> performances = performanceRepository.findAllByPopular();
+            case MINE -> performances = performanceRepository.findAllByUserId(userId);
+            default -> performances = performanceRepository.findAllByLatest();
+        }
+
+        return performances.stream() // 현재 신청 인원 반환
+                .map(p -> {
+                	// reservation table에서 공연 id 개수를 세어 저장
+                    int reserved = reservationRepository.countByPerformance_Pid(p.getPid());
+                    return PerformanceResponseDto.from(p, reserved);
+                })
+                .collect(Collectors.toList());
+	}
+}


### PR DESCRIPTION
## ✨ 주요 변경 사항
- 공연 카드 정렬하는 기능 추가(최신순, 인기 많은 순, 나의 예매)
- 공연마다 이미 예매 된 좌석 수, 전체 좌석 수 등 공연의 정보 확인 가능
- 사용자가 예매한 공연은 예매 취소 가능



## 📎 관련 이슈
Closes #8 