### PR TITLE
Feat/user reservations: 나의 예매 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/bootcamp/savemypodo/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bootcamp/savemypodo/config/jwt/JwtAuthenticationFilter.java
@@ -90,8 +90,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
         } catch (UserException e) {
-            log.error("❌ 인증 실패: {}", e.getErrorCode().getMessage());
-            throw e; // GlobalExceptionHandler로 전파
+            log.warn("🚫 [JWT Filter] UserException 발생 - {}: {}", e.getErrorCode(), e.getMessage());
+            setErrorResponse(response, e.getErrorCode(), request.getRequestURI());
+            return; // ❗ 더 이상 필터 체인을 진행하지 않음
         }
 
         filterChain.doFilter(request, response);
@@ -116,5 +117,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(authentication);
         log.info("🔐 사용자 인증 성공: {}", email);
+    }
+
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode, String path) throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String body = String.format("""
+        {
+          "status": %d,
+          "error": "%s",
+          "path": "%s"
+        }
+        """, errorCode.getStatus().value(), errorCode.getMessage(), path);
+
+        response.getWriter().write(body);
     }
 }

--- a/src/main/java/com/bootcamp/savemypodo/controller/UserController.java
+++ b/src/main/java/com/bootcamp/savemypodo/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.bootcamp.savemypodo.controller;
 
+import com.bootcamp.savemypodo.dto.reservation.MyReservationResponse;
 import com.bootcamp.savemypodo.dto.user.UserResponse;
 import com.bootcamp.savemypodo.entity.User;
 import com.bootcamp.savemypodo.repository.UserRepository;
+import com.bootcamp.savemypodo.service.ReservationService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -13,12 +15,15 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/user")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserRepository userRepository;
+    private final ReservationService reservationService;
 
     @PostMapping("/logout")
     public ResponseEntity<?> logout(@AuthenticationPrincipal User user,
@@ -48,4 +53,11 @@ public class UserController {
     public UserResponse getMyInfo(@AuthenticationPrincipal User user) {
         return new UserResponse(user.getEmail(), user.getNickname(), user.getRole().name());
     }
+
+    @GetMapping("/my-reservations")
+    public ResponseEntity<List<MyReservationResponse>> getMyReservations(@AuthenticationPrincipal User user) {
+        List<MyReservationResponse> reservations = reservationService.getMyReservationsByUser(user);
+        return ResponseEntity.ok(reservations);
+    }
+
 }

--- a/src/main/java/com/bootcamp/savemypodo/dto/reservation/MyReservationResponse.java
+++ b/src/main/java/com/bootcamp/savemypodo/dto/reservation/MyReservationResponse.java
@@ -1,0 +1,23 @@
+package com.bootcamp.savemypodo.dto.reservation;
+
+import com.bootcamp.savemypodo.entity.Reservation;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record MyReservationResponse(
+        Long rid,
+        String performanceTitle,
+        LocalDateTime date,
+        String sid
+) {
+    public static MyReservationResponse fromEntity(Reservation reservation) {
+        return MyReservationResponse.builder()
+                .rid(reservation.getId())
+                .performanceTitle(reservation.getPerformance().getTitle())
+                .date(reservation.getPerformance().getDate())
+                .sid(reservation.getSeat().getSid())
+                .build();
+    }
+}

--- a/src/main/java/com/bootcamp/savemypodo/entity/Performance.java
+++ b/src/main/java/com/bootcamp/savemypodo/entity/Performance.java
@@ -10,8 +10,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Entity
 @Table(name = "performances")
 public class Performance {

--- a/src/main/java/com/bootcamp/savemypodo/entity/Reservation.java
+++ b/src/main/java/com/bootcamp/savemypodo/entity/Reservation.java
@@ -1,18 +1,17 @@
 package com.bootcamp.savemypodo.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Service;
 
 @Entity
+@Getter
+@Setter
+@Service
 @Table(name = "reservations")
 public class Reservation {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	
 	@ManyToOne
@@ -22,4 +21,8 @@ public class Reservation {
 	@ManyToOne
 	@JoinColumn(name = "pid")
 	private Performance performance;
+
+	@OneToOne
+	@JoinColumn(name = "seat_id")
+	private Seat seat;
 }

--- a/src/main/java/com/bootcamp/savemypodo/entity/Seat.java
+++ b/src/main/java/com/bootcamp/savemypodo/entity/Seat.java
@@ -1,0 +1,29 @@
+package com.bootcamp.savemypodo.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "Seats")
+public class Seat {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String sid; // 예: A1, B3 등
+
+    private Boolean seatStatus;
+
+    @ManyToOne
+    @JoinColumn(name = "pid",referencedColumnName = "pid")
+    private Performance performance;
+}

--- a/src/main/java/com/bootcamp/savemypodo/entity/User.java
+++ b/src/main/java/com/bootcamp/savemypodo/entity/User.java
@@ -32,8 +32,6 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;                  // 사용자 역할 (예: USER, ADMIN)
 
-        // GOOGLE, KAKAO, NAVER
-
     private String refreshToken; // 리프레시 토큰
 
     // 유저 권한 설정 메소드

--- a/src/main/java/com/bootcamp/savemypodo/global/exception/ErrorCode.java
+++ b/src/main/java/com/bootcamp/savemypodo/global/exception/ErrorCode.java
@@ -8,7 +8,7 @@ public enum ErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 
     // 🔐 토큰 관련 에러
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Access Token이 만료되었습니다."),

--- a/src/main/java/com/bootcamp/savemypodo/repository/ReservationRepository.java
+++ b/src/main/java/com/bootcamp/savemypodo/repository/ReservationRepository.java
@@ -1,9 +1,12 @@
 package com.bootcamp.savemypodo.repository;
 
+import com.bootcamp.savemypodo.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
 
 import com.bootcamp.savemypodo.entity.Reservation;
+
+import java.util.List;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
@@ -15,4 +18,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     
     // 예매 취소
     void deleteByUser_IdAndPerformance_Pid(@Param("uid") Long uid, @Param("pid") Long pid);
+
+    // 해당 유저가 예매한 내역 반환
+    List<Reservation> findAllByUser(User user);
 }

--- a/src/main/java/com/bootcamp/savemypodo/repository/SeatRepository.java
+++ b/src/main/java/com/bootcamp/savemypodo/repository/SeatRepository.java
@@ -1,0 +1,12 @@
+package com.bootcamp.savemypodo.repository;
+
+import com.bootcamp.savemypodo.entity.Seat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SeatRepository extends JpaRepository<Seat, Long> {
+    List<Seat> findByPerformance_Pid(Long pid);
+    Optional<Seat> findByPerformance_PidAndSid(Long pid, String sid);
+}

--- a/src/main/java/com/bootcamp/savemypodo/service/ReservationService.java
+++ b/src/main/java/com/bootcamp/savemypodo/service/ReservationService.java
@@ -1,0 +1,25 @@
+package com.bootcamp.savemypodo.service;
+
+import com.bootcamp.savemypodo.dto.reservation.MyReservationResponse;
+import com.bootcamp.savemypodo.entity.Reservation;
+import com.bootcamp.savemypodo.entity.User;
+import com.bootcamp.savemypodo.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+
+    public List<MyReservationResponse> getMyReservationsByUser(User user) {
+        List<Reservation> reservations = reservationRepository.findAllByUser(user);
+        return reservations.stream()
+                .map(MyReservationResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/com/bootcamp/savemypodo/ReservationTest.java
+++ b/src/test/java/com/bootcamp/savemypodo/ReservationTest.java
@@ -1,0 +1,61 @@
+package com.bootcamp.savemypodo;
+
+import com.bootcamp.savemypodo.entity.*;
+import com.bootcamp.savemypodo.global.enums.Provider;
+import com.bootcamp.savemypodo.global.enums.Role;
+import com.bootcamp.savemypodo.repository.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+@SpringBootTest
+public class ReservationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PerformanceRepository performanceRepository;
+
+    @Autowired
+    private SeatRepository seatRepository;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Test
+    public void createDummyReservation() {
+        // uid = 1 유저 조회
+        User user = userRepository.findById(1L)
+                .orElseThrow(() -> new IllegalArgumentException("❌ 유저가 존재하지 않습니다."));
+
+        for (int i = 1; i <= 3; i++) {
+            // 공연 생성
+            Performance performance = new Performance();
+            performance.setTitle("공연 " + i);
+            performance.setSummary("설명 " + i);
+            performance.setDate(LocalDateTime.now().plusDays(i));
+            performance.setPrice(50000 + i * 1000);
+            performance.setSeatNumber(100);
+            performance = performanceRepository.save(performance);
+
+            // 좌석 생성
+            Seat seat = new Seat();
+            seat.setSid("A" + i); // 예: A1, A2, A3
+            seat.setSeatStatus(true);
+            seat.setPerformance(performance);
+            seat = seatRepository.save(seat);
+
+            // 예매 생성
+            Reservation reservation = new Reservation();
+            reservation.setUser(user);
+            reservation.setPerformance(performance);
+            reservation.setSeat(seat);  // Seat도 연결
+            reservationRepository.save(reservation);
+        }
+
+        System.out.println("✅ uid=1 유저의 예매 3건이 생성되었습니다.");
+    }
+}


### PR DESCRIPTION
## ✨ 주요 변경 사항
- 나의 예매 내역 조회 API (`GET /api/user/my-reservations`) 추가
- 사용자 인증 기반으로 본인의 예약 정보만 조회 가능
- 공연 및 좌석 정보를 함께 반환하도록 개선

## ✅ 체크리스트
- [x] 기능 동작 확인
- [x] 코드 리뷰 반영

## 📎 관련 이슈
Closes #6