### PR TITLE
Fix: 중복된 예약 불가 기능 추가 & 예약한 좌석 수 증가 로직 추가

### DIFF
--- a/src/main/java/com/bootcamp/savemypodo/controller/ReservationController.java
+++ b/src/main/java/com/bootcamp/savemypodo/controller/ReservationController.java
@@ -2,6 +2,7 @@ package com.bootcamp.savemypodo.controller;
 
 
 import com.bootcamp.savemypodo.dto.reservation.ReservationRequest;
+import com.bootcamp.savemypodo.dto.reservation.ReservationResponse;
 import com.bootcamp.savemypodo.entity.User;
 import com.bootcamp.savemypodo.service.ReservationService;
 import lombok.Data;
@@ -39,11 +40,5 @@ public class ReservationController {
         return ResponseEntity.ok(new ReservationResponse("성공적으로 취소 되었습니다."));
     }
 
-    // -> 이것 보다는 dto 패키지에 ReservationRequest, Response를 사용하는것을 추천
     
-
-    @Data
-    static class ReservationResponse {
-        private final String message;
-    }
 }

--- a/src/main/java/com/bootcamp/savemypodo/dto/musical/MusicalResponse.java
+++ b/src/main/java/com/bootcamp/savemypodo/dto/musical/MusicalResponse.java
@@ -11,16 +11,18 @@ import java.time.format.DateTimeFormatter;
 public record MusicalResponse(
         Long id,
         String title,
-        String posterUrl,
-        String description,
-        LocalDate date,
         String timeRange,
-        Long price,
-        String location,
-        Long duration,
-        Long reservedCount,
+        String description,
         Long remainingSeats,
-        boolean isReserved
+        Long totalSeats,
+        Long price,
+        String posterUrl,
+        boolean isReserved,
+        LocalDate date,
+        String location,
+        Long duration
+        
+        
 ) {
     public static MusicalResponse fromEntity(Musical musical, boolean isReserved) {
     	Long reservedCount = musical.getReservedCount();
@@ -37,9 +39,9 @@ public record MusicalResponse(
                 .price(musical.getPrice())
                 .location(musical.getLocation())
                 .duration(musical.getDuration())
-                .reservedCount(musical.getReservedCount())
                 .remainingSeats(remainingSeats)
                 .isReserved(isReserved)
+                .totalSeats(totalSeats)
                 .build();
     }
 

--- a/src/main/java/com/bootcamp/savemypodo/dto/reservation/ReservationResponse.java
+++ b/src/main/java/com/bootcamp/savemypodo/dto/reservation/ReservationResponse.java
@@ -1,10 +1,7 @@
 package com.bootcamp.savemypodo.dto.reservation;
 
 public record ReservationResponse(
-        boolean reserved,
-        boolean soldOut,
-        int seatNumber,
-        int currentReserved
+		String message
 ) {
 }
 

--- a/src/main/java/com/bootcamp/savemypodo/global/exception/ErrorCode.java
+++ b/src/main/java/com/bootcamp/savemypodo/global/exception/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
     // 🪑 좌석 관련 에러
     INVALID_SEAT_ROW(HttpStatus.BAD_REQUEST, "좌석 행 정보가 올바르지 않습니다. (A~J)"),
     INVALID_SEAT_COLUMN(HttpStatus.BAD_REQUEST, "좌석 열 정보가 유효하지 않습니다. (1~14)"),
-    SEAT_ALREADY_RESERVED(HttpStatus.CONFLICT, "해당 좌석은 이미 예약되었습니다.");
+    SEAT_ALREADY_RESERVED(HttpStatus.CONFLICT, "해당 좌석은 이미 예약되었습니다."),
+	ALREADY_RESERVED_MUSICAL(HttpStatus.CONFLICT, "해당 뮤지컬을 이미 예약하였습니다.");
 
     // 📅 예약 관련 에러
 

--- a/src/main/java/com/bootcamp/savemypodo/repository/ReservationRepository.java
+++ b/src/main/java/com/bootcamp/savemypodo/repository/ReservationRepository.java
@@ -24,6 +24,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 	boolean existsByUser_IdAndMusical_Id(Long userId, Long musicalId);
 
 	boolean existsByUserAndMusicalAndSeat(User user, Musical musical, Seat seat);
+	
 
     // 해당 유저가 예매한 내역 반환
     List<Reservation> findAllByUser(User user);

--- a/src/main/java/com/bootcamp/savemypodo/repository/SeatRepository.java
+++ b/src/main/java/com/bootcamp/savemypodo/repository/SeatRepository.java
@@ -1,6 +1,8 @@
 package com.bootcamp.savemypodo.repository;
 
 import com.bootcamp.savemypodo.entity.Seat;
+import com.bootcamp.savemypodo.entity.User;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,5 +13,7 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
     List<Seat> findByMusical_Id(Long musicalId);
 
     Optional<Seat> findByMusicalIdAndSeatName(Long musicalId, String seatName);
+
+	
 }
 

--- a/src/main/java/com/bootcamp/savemypodo/service/ReservationService.java
+++ b/src/main/java/com/bootcamp/savemypodo/service/ReservationService.java
@@ -60,7 +60,9 @@ public class ReservationService {
                 .build();
         reservationRepository.save(reservation);
 
-        // + 공연의 reservedCount 증가 로직 추가!
+        // 공연의 reservedCount 증가 
+        musical.setReservedCount(musical.getReservedCount() + 1);
+        musicalRepository.save(musical);
     }
 
     public List<MyReservationResponse> getMyReservationsByUser(User user) {

--- a/src/main/java/com/bootcamp/savemypodo/service/ReservationService.java
+++ b/src/main/java/com/bootcamp/savemypodo/service/ReservationService.java
@@ -32,7 +32,10 @@ public class ReservationService {
     @Transactional
     public void createReservation(User user, Long mid, String seatName) {
 
-        // + 해당 유저가 이미 해당 Musical 좌석을 예약 했는지 Check!
+    	boolean user_reserved = reservationRepository.existsByUser_IdAndMusical_Id(user.getId(), mid);
+        if (user_reserved) {
+        	throw new ReservationException(ErrorCode.ALREADY_RESERVED_MUSICAL);
+        }
 
         Optional<Seat> existingSeat = seatRepository.findByMusicalIdAndSeatName(mid, seatName);
         if (existingSeat.isPresent()) {


### PR DESCRIPTION
## ✨ 주요 변경 사항
- 같은 뮤지컬에 한해서 한 사용자가 하나의 예약만 하도록함 (프론트에서 불가하게 막았지만 한번 더 처리)
- 남는 좌석 수 musicalResponse에 포함
  - 예약할 때 예약한 좌석 수 증가 로직 추가

## ✅ 체크리스트
- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [ ] 관련 이슈 연결 (있는 경우)

## 📎 관련 이슈
