### PR TITLE
[Fix] JWT 필터 예외 경로 추가 및 OAuth 쿠키 보안 설정 개선

### DIFF
--- a/src/main/java/com/bootcamp/savemypodo/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bootcamp/savemypodo/config/jwt/JwtAuthenticationFilter.java
@@ -33,8 +33,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain)
             throws ServletException, IOException {
+        
         String uri = request.getRequestURI();
-        if (uri.equals("/") || uri.startsWith("/login") || uri.equals("/api/musicals")) {
+        if (uri.equals("/") || uri.startsWith("/login") || uri.equals("/api/musicals") || uri.equals("/actuator/prometheus") || uri.equals("/api/user/me")) {
             filterChain.doFilter(request, response); // 그냥 통과
         /*if (uri.equals("/") || uri.startsWith("/login") || uri.equals("/api/musicals")) {
         	filterChain.doFilter(request, response);*/

--- a/src/main/java/com/bootcamp/savemypodo/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bootcamp/savemypodo/config/jwt/JwtAuthenticationFilter.java
@@ -34,8 +34,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain)
             throws ServletException, IOException {
         String uri = request.getRequestURI();
-        if (uri.equals("/") || uri.startsWith("/login")) {
-        	filterChain.doFilter(request, response); // 그냥 통과
+        if (uri.equals("/") || uri.startsWith("/login") || uri.equals("/api/musicals")) {
+            filterChain.doFilter(request, response); // 그냥 통과
         /*if (uri.equals("/") || uri.startsWith("/login") || uri.equals("/api/musicals")) {
         	filterChain.doFilter(request, response);*/
             return;
@@ -88,17 +88,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 setAuthenticationFromAccessToken(newAccessToken, request);
                 log.info("🔄 Access Token 재발급 완료 for user: {}", email);
-            // 수정한 부분
+                // 수정한 부분
             } else {
-            	log.debug("🔒 토큰 없음—익명 사용자로 진행");
+                log.debug("🔒 토큰 없음—익명 사용자로 진행");
                 filterChain.doFilter(request, response);
                 return;
             	
             	/*log.warn("❗ 유효한 토큰이 존재하지 않음");
-                throw new UserException(ErrorCode.INVALID_TOKEN); */            
+                throw new UserException(ErrorCode.INVALID_TOKEN); */
             }
-                     
-        } catch (UserException e) {            
+
+        } catch (UserException e) {
             log.warn("🚫 [JWT Filter] UserException 발생 - {}: {}", e.getErrorCode(), e.getMessage());
             setErrorResponse(response, e.getErrorCode(), request.getRequestURI());
             return; // ❗ 더 이상 필터 체인을 진행하지 않음
@@ -134,12 +134,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         response.setCharacterEncoding("UTF-8");
 
         String body = String.format("""
-        {
-          "status": %d,
-          "error": "%s",
-          "path": "%s"
-        }
-        """, errorCode.getStatus().value(), errorCode.getMessage(), path);
+                {
+                  "status": %d,
+                  "error": "%s",
+                  "path": "%s"
+                }
+                """, errorCode.getStatus().value(), errorCode.getMessage(), path);
 
         response.getWriter().write(body);
     }

--- a/src/main/java/com/bootcamp/savemypodo/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bootcamp/savemypodo/config/jwt/JwtAuthenticationFilter.java
@@ -44,9 +44,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String accessToken = getTokenFromCookie(request, "accessToken");
         String refreshToken = getTokenFromCookie(request, "refreshToken");
 
-        log.debug("🔍 [JWT 필터] 요청 URI: {}", request.getRequestURI());
-        log.debug("🔑 accessToken 존재 여부: {}", accessToken != null);
-        log.debug("🔑 refreshToken 존재 여부: {}", refreshToken != null);
+        log.info("🔍 [JWT 필터] 요청 URI: {}", request.getRequestURI());
+        log.info("🔑 accessToken 존재 여부: {}", accessToken != null);
+        log.info("🔑 refreshToken 존재 여부: {}", refreshToken != null);
 
         try {
             if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
@@ -90,12 +90,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 log.info("🔄 Access Token 재발급 완료 for user: {}", email);
                 // 수정한 부분
             } else {
-                log.debug("🔒 토큰 없음—익명 사용자로 진행");
+                log.info("🔒 토큰 없음—익명 사용자로 진행");
                 filterChain.doFilter(request, response);
                 return;
-            	
-            	/*log.warn("❗ 유효한 토큰이 존재하지 않음");
-                throw new UserException(ErrorCode.INVALID_TOKEN); */
             }
 
         } catch (UserException e) {

--- a/src/main/java/com/bootcamp/savemypodo/config/security/OAuth2FailureHandler.java
+++ b/src/main/java/com/bootcamp/savemypodo/config/security/OAuth2FailureHandler.java
@@ -21,6 +21,7 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
         // 인증 실패시 메인 페이지로 이동
+        log.warn("❌ [OAuth2 Failure]: 인증 실패");
         response.sendRedirect(frontendUrl);
     }
 }

--- a/src/main/java/com/bootcamp/savemypodo/config/security/SecurityConfig.java
+++ b/src/main/java/com/bootcamp/savemypodo/config/security/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
 
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/login", "/api/musicals", "/actuator/prometheus").permitAll()
+                        .requestMatchers("/", "/login", "/api/musicals", "/actuator/prometheus", "/api/user/me").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/user/**", "/api/reservations/**", "/api/musicals/**").hasRole("USER")
                         .anyRequest().authenticated()

--- a/src/main/java/com/bootcamp/savemypodo/controller/UserController.java
+++ b/src/main/java/com/bootcamp/savemypodo/controller/UserController.java
@@ -3,6 +3,8 @@ package com.bootcamp.savemypodo.controller;
 import com.bootcamp.savemypodo.dto.reservation.MyReservationResponse;
 import com.bootcamp.savemypodo.dto.user.UserResponse;
 import com.bootcamp.savemypodo.entity.User;
+import com.bootcamp.savemypodo.global.exception.ErrorCode;
+import com.bootcamp.savemypodo.global.exception.UserException;
 import com.bootcamp.savemypodo.service.ReservationService;
 import com.bootcamp.savemypodo.service.redis.RedisMusicalService;
 import com.bootcamp.savemypodo.service.redis.RedisRefreshTokenService;
@@ -76,8 +78,19 @@ public class UserController {
     }
 
     @GetMapping("/me")
-    public UserResponse getMyInfo(@AuthenticationPrincipal User user) {
-        return new UserResponse(user.getEmail(), user.getNickname(), user.getRole().name());
+    public ResponseEntity<UserResponse> getMyInfo(@AuthenticationPrincipal User user) {
+        if (user == null) {
+            log.warn("❌ [/api/me] 사용자가 존재하지 않음");
+            throw new UserException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        UserResponse userResponse = new UserResponse(
+                user.getEmail(),
+                user.getNickname(),
+                user.getRole().name()
+        );
+
+        return ResponseEntity.ok(userResponse);
     }
 
     @GetMapping("/my-reservations")


### PR DESCRIPTION
## ✨ 주요 변경 사항
- `/api/musicals`, `/api/user/me`, `/actuator/prometheus` 경로에 대해 JWT 필터 예외 처리 추가
- OAuth2 로그인 성공 시 환경별 쿠키 설정 분리 (`localhost` vs 배포 환경)
- Secure, HttpOnly, SameSite 속성 등 보안 설정 강화
- `/api/user/me` 요청 시 인증 정보가 없을 경우 `USER_NOT_FOUND` 예외 발생 처리
- OAuth2 성공 처리 로깅 추가

## ✅ 체크리스트
- [x] 기능 동작 확인
- [x] 코드 리뷰 반영